### PR TITLE
Fixed crash in resumeDownload, if url wasn't given

### DIFF
--- a/lib/TaskExecuter.js
+++ b/lib/TaskExecuter.js
@@ -25,7 +25,7 @@ var normalizeUrl = function(url) {
 }
 
 var TaskExecuter = function(file, url, options) {
-	if (url !== null) {
+	if (url) {
 		url = normalizeUrl(url)
 	}
 


### PR DESCRIPTION
If you tried to resume a download without giving it an URL, it would have tried to normalize the non-existant url. This was because the last fix compared url to null, instead of just checking if it exists.